### PR TITLE
mono rebase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM lsiobase/xenial
+FROM lsiobase/mono
 MAINTAINER sparklyballs
 
 # environment settings
-ARG DEBIAN_FRONTEND="noninteractive"
 ENV XDG_CONFIG_HOME="/config/xdg"
 
 # set version label
@@ -10,20 +9,8 @@ ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
-# install packages
-RUN \
- apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-	--recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/debian wheezy main" \
-	| tee /etc/apt/sources.list.d/mono-xamarin.list && \
-
- apt-get update && \
- apt-get install -y \
-	libcurl3 \
-	libmono-cil-dev \
-	mediainfo && \
-
 # install radarr
+RUN \
  radarr_tag=$(curl -sX GET "https://api.github.com/repos/Radarr/Radarr/releases" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
  mkdir -p \
@@ -37,9 +24,7 @@ RUN \
 
 # clean up
  rm -rf \
-	/tmp/* \
-	/var/lib/apt/lists/* \
-	/var/tmp/*
+	/tmp/*
 
 # add local files
 COPY /root /

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ docker create \
 	-v <path to data>:/config \
 	-v <path to data>:/downloads \
 	-v <path to data>:/movies \
-	-e PGID=<gid> -e PUID=<uid>  \
+	-v /etc/localtime:/etc/localtime:ro \
 	-e TZ=<timezone> \
+	-e PGID=<gid> -e PUID=<uid>  \
 	-p 7878:7878 \
   linuxserver/radarr
 ```
@@ -45,11 +46,16 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-v /config` - Radarr Application Data
 * `-v /downloads` - Downloads Folder
 * `-v /movies` - Movie Share
+* `-v /etc/localtime` for timesync - see [Localtime](#localtime) for important information
+* `-e TZ` for timezone information, Europe/London - see [Localtime](#localtime) for important information
 * `-e PGID` for for GroupID - see below for explanation
 * `-e PUID` for for UserID - see below for explanation
-* `-e TZ` for timezone information, eg Europe/London
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it radarr /bin/bash`.
+
+## Localtime
+
+It is important that you either set `-v /etc/localtime:/etc/localtime:ro` or the TZ variable, mono will throw exceptions without one of them set.
 
 ### User / Group Identifiers
 
@@ -81,5 +87,6 @@ Access the webui at `<your-ip>:7878`, for more information check out [Radarr][ap
 
 ## Versions
 
++ **17.04.17:** Switch to using inhouse mono baseimage, adds python also.
 + **13.04.17:** Switch to official mono repository.
 + **10.01.17:** Initial Release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ rebase to inhouse mono baseimage
+ adds 90MB to final image size though..
+ clarify notes in README about localtime issue with mono 4.8 + 
+ adds python inherited from mono baseimage for postprocessing scripts