### PR TITLE
Workaround 'DownloadMonitoringService|Unable to retrieve queue and h...

### DIFF
--- a/root/etc/services.d/radarr/run
+++ b/root/etc/services.d/radarr/run
@@ -2,6 +2,8 @@
 
 cd /opt/radarr || exit
 
+export MONO_TLS_PROVIDER=legacy
+
 exec \
 	s6-setuidgid abc mono --debug Radarr.exe \
 	-nobrowser -data=/config


### PR DESCRIPTION
Sets MONO_TLS_PROVIDER=legacy before launching mono

closes #17 17