### PR TITLE
Remove debug for pos memory leak fix

### DIFF
--- a/root/etc/services.d/radarr/run
+++ b/root/etc/services.d/radarr/run
@@ -3,5 +3,5 @@
 cd /opt/radarr || exit
 
 exec \
-	s6-setuidgid abc mono --debug Radarr.exe \
+	s6-setuidgid abc mono Radarr.exe \
 	-nobrowser -data=/config


### PR DESCRIPTION
Please see a long list of memory leaks and raddar here:
https://github.com/Radarr/Radarr/issues/1580

This debug is not needed in docker/radarr/mono in my opinion.

@sparklyballs whisper :+1: 