### PR TITLE
using 5.14 tag for mono base version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/mono:xenial
+FROM lsiobase/mono:5.14
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/mono.arm64:xenial
+FROM lsiobase/mono.arm64:5.14
 
 # Add qemu to build on x86_64 systems
 COPY qemu-aarch64-static /usr/bin

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/mono.armhf:xenial
+FROM lsiobase/mono.armhf:5.14
 
 # Add qemu to build on x86_64 systems
 COPY qemu-arm-static /usr/bin

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ TLDR: Multi-arch support is changing from multiple repos to one repo per contain
 [![](https://images.microbadger.com/badges/image/linuxserver/radarr.svg)](https://microbadger.com/images/linuxserver/radarr "Get your own version badge on microbadger.com")
 ![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/radarr.svg)
 ![Docker Stars](https://img.shields.io/docker/stars/linuxserver/radarr.svg)
+[![Build Status](https://ci.linuxserver.io/buildStatus/icon?job=Docker-Pipeline-Builders/docker-radarr/master)](https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-radarr/job/master/)
+[![](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/radarr/latest/badge.svg)](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/radarr/latest/index.html)
 
 [Radarr](https://github.com/Radarr/Radarr) - A fork of Sonarr to work with movies à la Couchpotato.
 
@@ -36,6 +38,8 @@ TLDR: Multi-arch support is changing from multiple repos to one repo per contain
 
 Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list). 
 
+Simply pulling `linuxserver/radarr` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
+
 The architectures supported by this image are:
 
 | Architecture | Tag |
@@ -43,6 +47,7 @@ The architectures supported by this image are:
 | x86-64 | amd64-latest |
 | arm64 | arm64v8-latest |
 | armhf | arm32v6-latest |
+
 
 ## Usage
 
@@ -125,6 +130,7 @@ In this instance `PUID=1001` and `PGID=1001`, to find yours use `id user` as bel
     uid=1001(dockeruser) gid=1001(dockergroup) groups=1001(dockergroup)
 ```
 
+
 &nbsp;
 ## Application Setup
 
@@ -141,8 +147,28 @@ Access the webui at `<your-ip>:7878`, for more information check out [Radarr](ht
 * image version number
   * `docker inspect -f '{{ index .Config.Labels "build_version" }}' linuxserver/radarr`
 
+## Updating Info
+
+Most of our images are static, versioned, and require an image update and container recreation to update the app inside. With some exceptions (ie. nextcloud, plex), we do not recommend or support updating apps inside the container. Please consult the [Application Setup](#application-setup) section above to see if it is recommended for the image.  
+  
+Below are the instructions for updating containers:  
+  
+### Via Docker Run/Create
+* Update the image: `docker pull linuxserver/radarr`
+* Stop the running container: `docker stop radarr`
+* Delete the container: `docker rm radarr`
+* Recreate a new container with the same docker create parameters as instructed above (if mapped correctly to a host folder, your `/config` folder and settings will be preserved)
+* Start the new container: `docker start radarr`
+* You can also remove the old dangling images: `docker image prune`
+
+### Via Docker Compose
+* Update the image: `docker-compose pull linuxserver/radarr`
+* Let compose update containers as necessary: `docker-compose up -d`
+* You can also remove the old dangling images: `docker image prune`
+
 ## Versions
 
+* **09.02.19:** - Stick mono version at 5.14 stable
 * **09.09.18:** - Add pipeline build process.
 * **24.02.18:** - Add nightly branch.
 * **06.02.18:** - Radarr repo changed owner.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -48,6 +48,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "09.02.19:", desc: "Stick mono version at 5.14 stable" }
   - { date: "09.09.18:", desc: "Add pipeline build process." }
   - { date: "24.02.18:", desc: "Add nightly branch." }
   - { date: "06.02.18:", desc: "Radarr repo changed owner." }


### PR DESCRIPTION
This needs testing along with review, it uses a mono base image at 5.14 stable.