### PR TITLE
Master - adding LTS branch for us to freeze a stable mono for downstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/mono:bionic
+FROM lsiobase/mono:LTS
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/mono:arm64v8-bionic
+FROM lsiobase/mono:arm64v8-LTS
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/mono:arm32v7-bionic
+FROM lsiobase/mono:arm32v7-LTS
 
 # set version label
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **01.08.19:** - Rebase to Linuxserver LTS mono version.
 * **13.06.19:** - Add env variable for setting umask.
 * **10.05.19:** - Rebase to Bionic.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -48,6 +48,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "01.08.19:", desc: "Rebase to Linuxserver LTS mono version." }
   - { date: "13.06.19:", desc: "Add env variable for setting umask." }
   - { date: "10.05.19:", desc: "Rebase to Bionic." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }


### PR DESCRIPTION
We already have a pretty solid smoke test with people reverting to 5.14 tags for stuff busted at Mono 6.0. 

There are 10 of these across our radarr, sonarr, lidarr, and duplicati repos to shift them all away from Mono 6.0 and use a Stable LTS mono tag currently 5.14. 