### PR TITLE
Remove extra volumes from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ COPY /root /
 
 # ports and volumes
 EXPOSE 7878
-VOLUME /config /downloads /movies
+VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -42,4 +42,4 @@ COPY /root /
 
 # ports and volumes
 EXPOSE 7878
-VOLUME /config /downloads /movies
+VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -42,4 +42,4 @@ COPY /root /
 
 # ports and volumes
 EXPOSE 7878
-VOLUME /config /downloads /movies
+VOLUME /config


### PR DESCRIPTION
## Description:

Specifying the volumes in the Dockerfile is unnecessary and can lead to
excessive orphaned volume if the user chooses to use different paths at
runtime.

## Benefits of this PR and context:

This is related to linuxserver/docker-sonarr#133

The `downloads` and `movies` volumes are actually not used by the initial container and are completely dependent on how users configure Radarr.

Furthermore, the default volume configuration encourages a setup that can lead to performance issues and redundant data by preventing hard linking. Both [Sonnar's own documentation](https://sonarr.tv/#downloads-v3-docker) and the [best practices wiki page on the _/r/usenet_ subreddit](https://www.reddit.com/r/usenet/wiki/docker#wiki_consistent_and_well_planned_paths) discourages the default volume setup.

This also allows user the flexibility to use the same volume for downloads and media (to solve the hardlink issue - see #11) without having the container create unnecessary volumes.

Removing the volumes from the Dockerfile does not prevent users from having the README instructions succeed, but does allow for more flexibility without the creation of unnecessary unused volumes. Removing the volumes also does not change much of the default behavior of the container. If the volumes were previously unmapped or unnamed, users would lose their data if they didn't know where to look for the anonymous volume to remount. 

## How Has This Been Tested?

Built the docker container and verified no extra volumes were created.

## Source / References:
* https://sonarr.tv/#downloads-v3-docker
* https://www.reddit.com/r/usenet/wiki/docker#wiki_consistent_and_well_planned_paths
* linuxserver/docker-sonarr#133
* #11 
