### PR TITLE
ingest sys package from eoan repos on preview branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,13 @@ ENV XDG_CONFIG_HOME="/config/xdg"
 
 RUN \
  echo "**** install packages ****" && \
+ sed -i 's/bionic/eoan/g' /etc/apt/sources.list && \
  apt-get update && \
  apt-get install --no-install-recommends -y \
 	jq \
-	libicu60 \
-	libmediainfo0v5 && \
+	libicu63 \
+	libmediainfo0v5 \
+	sqlite3 && \
  echo "**** install radarr ****" && \
  mkdir -p /opt/radarr && \
  if [ -z ${RADARR_RELEASE+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,11 +14,13 @@ ENV XDG_CONFIG_HOME="/config/xdg"
 
 RUN \
  echo "**** install packages ****" && \
+ sed -i 's/bionic/eoan/g' /etc/apt/sources.list && \
  apt-get update && \
  apt-get install --no-install-recommends -y \
 	jq \
-	libicu60 \
-	libmediainfo0v5 && \
+	libicu63 \
+	libmediainfo0v5 \
+	sqlite3 && \
  echo "**** install radarr ****" && \
  mkdir -p /opt/radarr && \
  if [ -z ${RADARR_RELEASE+x} ]; then \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,11 +14,13 @@ ENV XDG_CONFIG_HOME="/config/xdg"
 
 RUN \
  echo "**** install packages ****" && \
+ sed -i 's/bionic/eoan/g' /etc/apt/sources.list && \
  apt-get update && \
  apt-get install --no-install-recommends -y \
 	jq \
-	libicu60 \
-	libmediainfo0v5 && \
+	libicu63 \
+	libmediainfo0v5 \
+	sqlite3 && \
  echo "**** install radarr ****" && \
  mkdir -p /opt/radarr && \
  if [ -z ${RADARR_RELEASE+x} ]; then \

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **01.06.20:** - Use Eoan packages for preview branch.
 * **10.15.19:** - Use Netcore builds for preview branch.
 * **08.09.19:** - Pull artifacts from new upstream Azure build env.
 * **01.08.19:** - Rebase to Linuxserver LTS mono version.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -46,6 +46,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "01.06.20:", desc: "Use Eoan packages for preview branch." }
   - { date: "10.15.19:", desc: "Use Netcore builds for preview branch." }
   - { date: "08.09.19:", desc: "Pull artifacts from new upstream Azure build env." }
   - { date: "01.08.19:", desc: "Rebase to Linuxserver LTS mono version." }


### PR DESCRIPTION
Because we are netcore on preview the only thing I can think about this breaking is if people have scripts hooked into this container and the packages they use have different names. 

Upstream needs a more modern version of medianfo and sqlite.

closes #75 