### PR TITLE
Use latest ffprobe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:3.18
+FROM ghcr.io/linuxserver/baseimage-alpine:3.19
 
 # set version label
 ARG BUILD_DATE
@@ -18,7 +18,9 @@ RUN \
   apk add -U --upgrade --no-cache \
     icu-libs \
     sqlite-libs \
-    xmlstarlet && \
+    xmlstarlet \
+    jq \
+    curl && \
   echo "**** install radarr ****" && \
   mkdir -p /app/radarr/bin && \
   if [ -z ${RADARR_RELEASE+x} ]; then \
@@ -31,6 +33,11 @@ RUN \
   tar xzf \
     /tmp/radarr.tar.gz -C \
     /app/radarr/bin --strip-components=1 && \
+  echo "**** download and replace ffprobe ****" && \
+  curl -o /tmp/ffmpeg-release-64bit-static.tar.xz -L "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz" && \
+  tar -xJf /tmp/ffmpeg-release-64bit-static.tar.xz -C /tmp && \
+  mv /tmp/ffmpeg-*-amd64-static/ffprobe /app/radarr/bin/ffprobe && \
+  chmod +x /app/radarr/bin/ffprobe && \
   echo -e "UpdateMethod=docker\nBranch=${RADARR_BRANCH}\nPackageVersion=${VERSION}\nPackageAuthor=[linuxserver.io](https://linuxserver.io)" > /app/radarr/package_info && \
   echo "**** cleanup ****" && \
   rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.18
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.19
 
 # set version label
 ARG BUILD_DATE
@@ -17,7 +17,9 @@ RUN \
   apk add -U --upgrade --no-cache \
     icu-libs \
     sqlite-libs \
-    xmlstarlet && \
+    xmlstarlet \
+    jq \
+    curl && \
   echo "**** install radarr ****" && \
   mkdir -p /app/radarr/bin && \
   if [ -z ${RADARR_RELEASE+x} ]; then \
@@ -30,6 +32,11 @@ RUN \
   tar xzf \
     /tmp/radarr.tar.gz -C \
     /app/radarr/bin --strip-components=1 && \
+  echo "**** download and replace outdated ffprobe ****" && \
+  curl -o /tmp/ffmpeg-release-64bit-static.tar.xz -L "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz" && \
+  tar -xJf /tmp/ffmpeg-release-64bit-static.tar.xz -C /tmp && \
+  mv /tmp/ffmpeg-*-arm64-static/ffprobe /app/radarr/bin/ffprobe && \
+  chmod +x /app/radarr/bin/ffprobe && \
   echo -e "UpdateMethod=docker\nBranch=${RADARR_BRANCH}\nPackageVersion=${VERSION}\nPackageAuthor=[linuxserver.io](https://linuxserver.io)" > /app/radarr/package_info && \
   echo "**** cleanup ****" && \
   rm -rf \


### PR DESCRIPTION
I recently ran into an issue that's being caused by the outdated ffprobe binary that's included in the containers here.

This PR uses a more recent version of the binary which solved my problem.  Sharing here in case it's a welcome change.

I also bumped the alpine base and added some missing binaries for the apk add command.

This goes into more detail about the problem I ran into:
https://www.reddit.com/r/radarr/comments/1aog9bh/outdated_ffprobe_binary_failing_to_probe_media/